### PR TITLE
fixed nodemon issue in npm start 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "nodemon": "^2.0.15"
   },
   "scripts": {
-    "start": "nodemon --inspect=0.0.0.0:9229 index.js",
+    "start": "node_modules/nodemon/bin/nodemon.js --inspect=0.0.0.0:9229 index.js",
     "start-prod": "node index.js"
   }
 }


### PR DESCRIPTION
Fix for https://github.com/loft-sh/devspace-quickstart-nodejs/issues/8

Update `package.json` with below

`    "start": "node_modules/nodemon/bin/nodemon.js --inspect=0.0.0.0:9229 index.js"`

 This doesn't refer symlinked version of nodemon now and we won't see the errors